### PR TITLE
Use the team's name when a team review is requested

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 110
+  Max: 113
 
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/app/review/pull_request.rb
+++ b/app/review/pull_request.rb
@@ -30,7 +30,11 @@ module Review
       end
 
       def reviewer
-        Directory.lookup github_login: params[:requested_reviewer][:login]
+        if params.key? :requested_reviewer
+          Directory.lookup github_login: params[:requested_reviewer][:login]
+        else
+          MissingPerson.new params[:requested_team][:name]
+        end
       end
 
       def review_submitter
@@ -74,9 +78,13 @@ module Review
               requires :login, type: String
             end
           end
-          requires :requested_reviewer, type: Hash do
+          optional :requested_reviewer, type: Hash do
             requires :login, type: String
           end
+          optional :requested_team, type: Hash do
+            requires :name, type: String
+          end
+          exactly_one_of :requested_reviewer, :requested_team
         end
 
         post do

--- a/spec/review/pull_request_spec.rb
+++ b/spec/review/pull_request_spec.rb
@@ -37,22 +37,44 @@ RSpec.describe Review::PullRequest do
   end
 
   context 'POST /pr/review/request' do
-    let(:params) do
-      { pull_request: {
-        html_url: 'github.com/Jared-Prime/review/pulls/1',
-        user: { login: 'Jared-Prime' }
-      },
-        requested_reviewer: { login: 'somebody-else' } }
-    end
-
-    it 'proxies message to Slack' do
-      Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
-        post '/pr/review/request', params
+    context 'with a requested reviewer' do
+      let(:params) do
+        { pull_request: {
+          html_url: 'github.com/Jared-Prime/review/pulls/1',
+          user: { login: 'Jared-Prime' }
+        },
+          requested_reviewer: { login: 'somebody-else' } }
       end
 
-      expect(JSON.parse(last_response.body)).to include(
-        'contents' => 'Jared needs somebody-else to review github.com/Jared-Prime/review/pulls/1'
-      )
+      it 'proxies message to Slack' do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
+          post '/pr/review/request', params
+        end
+
+        expect(JSON.parse(last_response.body)).to(
+          include('contents' => 'Jared needs somebody-else to review github.com/Jared-Prime/review/pulls/1')
+        )
+      end
+    end
+
+    context 'with a requested team' do
+      let(:params) do
+        { pull_request: {
+          html_url: 'github.com/Jared-Prime/review/pulls/1',
+          user: { login: 'Jared-Prime' }
+        },
+          requested_team: { name: 'My Team' } }
+      end
+
+      it 'proxies message to Slack' do
+        Timecop.freeze(Time.parse('2018-07-08 11:14:15')) do
+          post '/pr/review/request', params
+        end
+
+        expect(JSON.parse(last_response.body)).to(
+          include('contents' => 'Jared needs My Team to review github.com/Jared-Prime/review/pulls/1')
+        )
+      end
     end
   end
 


### PR DESCRIPTION
## Problem:

When a PR review is requested from a team, there's currently no Slack message posted.

## Reproduction:

1. Open a PR and request review from a team instead of an individual

## Solution:

Extract the team name from the payload sent to the webhook and use that in the Slack message